### PR TITLE
Raise exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 # This is the configuration used to check the rubocop source code.
 
+require:
+   - ./lib/rubocop/cop/style/raise_exception.rb
+
 inherit_from: .rubocop_todo.yml
 
 AllCops:

--- a/lib/rubocop/cop/style/raise_exception.rb
+++ b/lib/rubocop/cop/style/raise_exception.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+# frozen_string_literal: true
+# author: Harry Lee
+
+module RuboCop
+  module Cop
+    module Style
+      # This cop checks for uses of `raise e`.
+      # @example
+      # case e
+      # when condition
+      #   statement
+      # else
+      #   raise e
+      # end
+      class RaiseException < Cop
+        MSG = 'Raise strings or constants, not variables.'.freeze
+
+        ALLOWED_TYPES = [:const, :str]
+
+        def on_send(node)
+          return unless node.command?(:raise)
+
+          _receiver, _selector, *args = *node
+
+          first_arg, = *args
+
+          add_offense(node, :expression, MSG) unless ALLOWED_TYPES.include?(first_arg.type)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/style/raise_exception_spec.rb
+++ b/spec/rubocop/cop/style/raise_exception_spec.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'spec_helper'
+require './lib/rubocop/cop/style/raise_exception.rb'
+
+describe RuboCop::Cop::Style::RaiseException do
+  subject(:cop) { described_class.new }
+
+  it 'reports an offense for a raise with variables' do
+    inspect_source(cop, 'raise e, msg')
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'reports an offense for a raise with variables' do
+    inspect_source(cop, 'raise Error, msg')
+    expect(cop.offenses.size).to eq(0)
+  end
+
+  it 'reports an offense for a raise with variables' do
+    inspect_source(cop, 'raise "my error", msg')
+    expect(cop.offenses.size).to eq(0)
+  end
+end


### PR DESCRIPTION
Create raise_exception to check 'raise variable', like 'raise e'. Method type const and str will be allowed to use. I called raise_exception.rb in .rubocop.yml for custom cops. 
